### PR TITLE
Change link for SL full pdf -> GDrive

### DIFF
--- a/content/chapters/00_all/_index.md
+++ b/content/chapters/00_all/_index.md
@@ -6,9 +6,13 @@ title: "All Slides Chapters 1-10 and 11-19"
 
 Complete PDF of all lecture slides from chapters 1-10:
 
-[Download](https://drive.google.com/file/d/16O-rVIPJVpLIZ9-qb7BRIJxomCXcrNgL/view?usp=share_link)
+[Download](https://drive.google.com/file/d/16O-rVIPJVpLIZ9-qb7BRIJxomCXcrNgL)
 
 Complete PDF of all lecture slides from chapters 11-19:
 
-{{< pdfjs file="https://github.com/slds-lmu/lecture_sl/blob/main/slides-pdf/lecture_sl.pdf" >}}
+[Download](https://drive.google.com/file/d/1SLdDhtZ39IFvRExb7v8h4tgbUgtjgqFX)
 
+<!-- 
+Defunct old link as lecture_sl.pdf has been moved to GDrive SLDS/Supervised Learning
+{{< pdfjs file="https://github.com/slds-lmu/lecture_sl/blob/main/slides-pdf/lecture_sl.pdf" >}} 
+-->


### PR DESCRIPTION
See https://github.com/slds-lmu/lecture_sl/pull/231

Moving the large PDFs from git to GDrive and updating links in the process.